### PR TITLE
Add the ability to change the functions in the quickfix list.

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,4 +1,4 @@
-column_width = 120
+column_width = 80
 line_endings = "Unix"
 indent_type = "Spaces"
 indent_width = 2

--- a/README.md
+++ b/README.md
@@ -33,16 +33,15 @@ the other uses the quickfix list as a source of the functions to change.
 This is the default version when running `change_function()`. It allows for a
 quick way to change function arguments, but sacrifices flexibility.
 
-1. Run the `:lua
-   require("change-function").change_function_via_lsp_references()` or `:lua
-   require("change-function").change_function()` command to open up the
+1. Run the `require("change-function").change_function_via_lsp_references()` or
+   `require("change-function").change_function()` command to open up the
    reorganisation window.
 2. Swap whatever arguments you need using the specified mappings.
 3. Press enter and confirm
 ### Using the quickfix list.
 
-1. Add your references using a command, for example `:lua
-   vim.lsp.references({includeDeclaration = true})`
+1. Add your references using a command, for example
+   `vim.lsp.references({includeDeclaration = true})`
 2. Modify the quickfix list with whatever workflow you currently use.
 3. Run the `:lua require("change-function").change_function_via_qf()` command to
    open up the reorganisation window.
@@ -93,7 +92,9 @@ change_function.setup({
     move_up = '<S-k>',
     confirm = '<enter>',
   },
-  quickfix_source = "cursor",
+  -- Specifies whether or not to use the first entry as the arguments for the
+  -- swapping window or the function at the cursor.
+  quickfix_source = "entry",
 })
 
 vim.api.nvim_set_keymap('n', '<leader>cr', '', {

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ change_function.setup({
     move_up = '<S-k>',
     confirm = '<enter>',
   },
-  -- Specifies whether or not to use the first entry as the arguments for the
+  -- Specifies whether or not to use the selected entry as the arguments for the
   -- swapping window or the function at the cursor.
   quickfix_source = "entry",
 })

--- a/README.md
+++ b/README.md
@@ -24,9 +24,36 @@ Use your favourite package manager to install `change-function.nvim`
 ```
 
 ## Usage
-There is currently a singular function `change_function()` which opens up the
-menu, for example: binding it to a key. You may call setup to customise some
-options with nui and keybindings within `change-function.nvim`.
+There are currently different ways to use this plugin. One automatically using
+LSP references (this is the default when using the `change_function()` function), 
+the other uses the quickfix list as a source of the functions to change.
+
+### Automatically via LSP references.
+
+This is the default version when running `change_function()`. It allows for a
+quick way to change function arguments, but sacrifices flexibility.
+
+1. Run the `:lua
+   require("change-function").change_function_via_lsp_references()` or `:lua
+   require("change-function").change_function()` command to open up the
+   reorganisation window.
+2. Swap whatever arguments you need using the specified mappings.
+3. Press enter and confirm
+### Using the quickfix list.
+
+1. Add your references using a command, for example `:lua
+   vim.lsp.references({includeDeclaration = true})`
+2. Modify the quickfix list with whatever workflow you currently use.
+3. Run the `:lua require("change-function").change_function_via_qf()` command to
+   open up the reorganisation window.
+4. Swap whatever arguments you need using the specified mappings.
+5. Press enter and confirm
+
+The quickfix list method allows for
+- Much more flexibility, as you can use plugins such as `quicker.nvim` to be
+  able to modify the list and include references that you want to change.
+- Allows you to be able to see what the functions that will be changed before
+  actually running the command.
 
 ```lua
 local change_function = require('change-function')
@@ -65,7 +92,8 @@ change_function.setup({
     move_down = '<S-j>',
     move_up = '<S-k>',
     confirm = '<enter>',
-  }
+  },
+  quickfix_source = "cursor",
 })
 
 vim.api.nvim_set_keymap('n', '<leader>cr', '', {

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ quick way to change function arguments, but sacrifices flexibility.
 5. Press enter and confirm
 
 The quickfix list method allows for
-- Much more flexibility, as you can use plugins such as `quicker.nvim` to be
-  able to modify the list and include references that you want to change.
+- Much more flexibility, as you can use existing quickfix workflows and use
+  plugins such as `nvim-bqf`, `quicker.nvim` or `listish.nvim` to be able to
+  modify the list and include references that you want to change.
 - Allows you to be able to see what the functions that will be changed before
   actually running the command.
 
@@ -97,8 +98,12 @@ change_function.setup({
   quickfix_source = "entry",
 })
 
-vim.api.nvim_set_keymap('n', '<leader>cr', '', {
+vim.api.nvim_set_keymap('n', '<leader>crl', '', {
   callback = change_function.change_function,
+})
+
+vim.api.nvim_set_keymap('n', '<leader>crq', '', {
+  callback = change_function.change_function_via_qf,
 })
 ```
 

--- a/lua/change-function/config.lua
+++ b/lua/change-function/config.lua
@@ -33,6 +33,7 @@ local defaults = {
     return {
       enter = true,
       focusable = true,
+      relative = "win",
       border = {
         style = "rounded",
         text = {
@@ -51,7 +52,7 @@ local defaults = {
     }
   end,
 
-  quickfix_source = "cursor",
+  quickfix_source = "entry",
 
   mappings = {
     quit = "q",

--- a/lua/change-function/config.lua
+++ b/lua/change-function/config.lua
@@ -1,26 +1,29 @@
----@enum MappingName
-local mapping_default = {
-  quit = "q",
-  quit2 = "<esc>",
-  move_down = "<S-j>",
-  move_up = "<S-k>",
-  confirm = "<enter>",
-}
+---@class Mappings
+---@field quit? string
+---@field quit2? string
+---@field move_down? string
+---@field move_up? string
+---@field confirm? string
 
----@enum QuickFixSource
-local quick_fix_source = {
-  entry = "entry",
-  cursor = "cursor",
-}
+---@class InternalMappings
+---@field quit string
+---@field quit2 string
+---@field move_down string
+---@field move_up string
+---@field confirm string
 
 ---@class ChangeFunctionConfig
 ---@field queries? table<string, string>
 ---@field nui? fun (node_name: string): NuiPopup
----@field mappings? table<MappingName, string>
----@field quickfix_source? QuickFixSource
+---@field mappings? Mappings
+---@field quickfix_source? "entry" | "cursor"
 
+---@class InternalChangeFunctionConfig
+---@field queries table<string, string>
+---@field nui fun (node_name: string): NuiPopup
+---@field mappings Mappings
+---@field quickfix_source "entry" | "cursor"
 local defaults = {
-
   queries = {
     rust = "function_params",
     lua = "function_params",
@@ -48,7 +51,7 @@ local defaults = {
     }
   end,
 
-  quickfix_source = "entry",
+  quickfix_source = "cursor",
 
   mappings = {
     quit = "q",
@@ -58,10 +61,15 @@ local defaults = {
     confirm = "<enter>",
   },
 }
-local config = {}
 
-function config.set_default(user_defaults)
-  config.config = vim.tbl_deep_extend("keep", user_defaults, defaults)
+---@class ConfigManager
+---@field config InternalChangeFunctionConfig
+local config_manager = {
+  config = defaults,
+}
+
+function config_manager.set_default(user_defaults)
+  config_manager.config = vim.tbl_deep_extend("keep", user_defaults, defaults)
 end
 
-return config
+return config_manager

--- a/lua/change-function/config.lua
+++ b/lua/change-function/config.lua
@@ -1,4 +1,19 @@
+---@enum MappingName
+local mapping_default = {
+  quit = "q",
+  quit2 = "<esc>",
+  move_down = "<S-j>",
+  move_up = "<S-k>",
+  confirm = "<enter>",
+}
+
+---@class ChangeFunctionConfig
+---@field queries? table<string, string>
+---@field nui? fun (node_name: string): NuiPopup
+---@field mappings? table<MappingName, string>
+
 local defaults = {
+
   queries = {
     rust = "function_params",
     lua = "function_params",

--- a/lua/change-function/config.lua
+++ b/lua/change-function/config.lua
@@ -7,10 +7,17 @@ local mapping_default = {
   confirm = "<enter>",
 }
 
+---@enum QuickFixSource
+local quick_fix_source = {
+  entry = "entry",
+  cursor = "cursor",
+}
+
 ---@class ChangeFunctionConfig
 ---@field queries? table<string, string>
 ---@field nui? fun (node_name: string): NuiPopup
 ---@field mappings? table<MappingName, string>
+---@field quickfix_source? QuickFixSource
 
 local defaults = {
 
@@ -41,6 +48,8 @@ local defaults = {
     }
   end,
 
+  quickfix_source = "entry",
+
   mappings = {
     quit = "q",
     quit2 = "<esc>",
@@ -54,7 +63,5 @@ local config = {}
 function config.set_default(user_defaults)
   config.config = vim.tbl_deep_extend("keep", user_defaults, defaults)
 end
-
-config.set_default({})
 
 return config

--- a/lua/change-function/init.lua
+++ b/lua/change-function/init.lua
@@ -31,8 +31,14 @@ local M = {}
 IDENTIFYING_CAPTURES = { ["function_name"] = true, ["method_name"] = true }
 ARGUMENT_CAPTURES = { ["parameter.inner"] = true, ["argument.inner"] = true }
 
-local function get_queries()
-  return ts.query.get(vim.bo.filetype, config_manager.config.queries[vim.bo.filetype] or "textobjects")
+local function get_queries(bufnr)
+  if bufnr == nil then
+    bufnr = 0
+  end
+  return ts.query.get(
+    vim.bo[bufnr].filetype,
+    config_manager.config.queries[vim.bo[bufnr].filetype] or "textobjects"
+  )
 end
 
 local function print_error(msg)
@@ -45,14 +51,22 @@ end
 ---@param position integer[] The cursor of the expected function signature
 ---@return {range: TextRange, text: string}[]? The range of the arguments in the signature + the text it contains.
 local function get_arguments(node, bufnr, position)
-  local query_function = get_queries()
+  local query_function = get_queries(bufnr)
 
   if query_function == nil then
     print_error("Queries are not available for this filetype")
     return
   end
 
-  while query_function:iter_matches(node, bufnr, nil, nil, { all = true, max_start_depth = 0 })() == nil do
+  while
+    query_function:iter_matches(
+      node,
+      bufnr,
+      nil,
+      nil,
+      { all = true, max_start_depth = 0 }
+    )() == nil
+  do
     node = node:parent()
     if node == nil then
       print_error(
@@ -69,14 +83,25 @@ local function get_arguments(node, bufnr, position)
 
   local arguments = {}
   local ignore = {}
-  for _, match, _ in query_function:iter_matches(node, bufnr, nil, nil, { all = true, max_start_depth = 0 }) do
+  for _, match, _ in
+    query_function:iter_matches(
+      node,
+      bufnr,
+      nil,
+      nil,
+      { all = true, max_start_depth = 0 }
+    )
+  do
     for id, nodes in pairs(match) do
       local capture_name = query_function.captures[id]
 
       for _, matched_node in ipairs(nodes) do
         local range, text = range_text(matched_node, bufnr)
 
-        if (IDENTIFYING_CAPTURES[capture_name] ~= nil) and not inside_range(range, position) then
+        if
+          (IDENTIFYING_CAPTURES[capture_name] ~= nil)
+          and not inside_range(range, position)
+        then
           print_error(
             string.format(
               "Could not find a function at (%d, %d) in the file %s",
@@ -119,7 +144,8 @@ local function get_text_edits(position, changes)
   vim.fn.bufload(position.bufnr)
 
   local pos = position.location
-  local matched_node = ts.get_node({ pos = pos, bufnr = position.bufnr, lang = vim.bo.filetype })
+  local matched_node =
+    ts.get_node({ pos = pos, bufnr = position.bufnr, lang = vim.bo.filetype })
   if matched_node == nil then
     print_error(
       string.format(
@@ -198,14 +224,15 @@ local function update_at_positions(positions, changes)
   end
 end
 
-function M.update_qf_list()
+function M.change_function_via_qf()
   local list = vim.fn.getqflist({ idx = 0, items = true })
   local items = list.items
   local idx = list.idx
   local curr_entry = items[idx]
   local pos = { items[idx].lnum - 1, items[idx].col - 1 }
 
-  local curr_node = ts.get_node({ bufnr = curr_entry.bufnr, pos = pos, lang = vim.bo.filetype })
+  local curr_node =
+    ts.get_node({ bufnr = curr_entry.bufnr, pos = pos, lang = vim.bo.filetype })
   if curr_node ~= nil then
     local arguments = get_arguments(curr_node, curr_entry.bufnr, pos)
     if arguments == nil then
@@ -218,28 +245,44 @@ function M.update_qf_list()
       return { line = i.text, id = index }
     end, arguments)
 
-    ui.open_ui(lines, ts.get_node_text(curr_node, curr_entry.bufnr, {}), function(swapped_lines)
-      local positions = vim
+    ui.open_ui(
+      lines,
+      ts.get_node_text(curr_node, curr_entry.bufnr, {}),
+      function(swapped_lines)
+        local positions = vim
           .iter(items)
           :map(function(qf_entry)
-            return { bufnr = qf_entry.bufnr, location = { qf_entry.lnum - 1, qf_entry.col - 1 } }
+            return {
+              bufnr = qf_entry.bufnr,
+              location = { qf_entry.lnum - 1, qf_entry.col - 1 },
+            }
           end)
           :totable()
 
-      update_at_positions(positions, swapped_lines)
-    end)
+        update_at_positions(positions, swapped_lines)
+      end
+    )
   end
 end
 
-local function make_lsp_request(buf, method, params)
+function M.change_function_via_lsp_references()
   local query_function = get_queries()
+
+  local bufnr = api.nvim_get_current_buf()
+
+  local method = "textDocument/references"
+  local params = {
+    textDocument = { uri = vim.uri_from_bufnr(bufnr) },
+    position = convert_win_cursor_to_position(0),
+    context = { includeDeclaration = true },
+  }
 
   if query_function == nil then
     print_error("Could not find a query for this filetype")
     return
   end
 
-  vim.lsp.buf_request_all(buf, method, params, function(results)
+  vim.lsp.buf_request_all(bufnr, method, params, function(results)
     for _, res in ipairs(results) do
       if res.error then
         print_error("An error occured while fetching references: " .. res.error)
@@ -252,7 +295,7 @@ local function make_lsp_request(buf, method, params)
       return
     end
 
-    local arguments = get_arguments(curr_node, buf, {
+    local arguments = get_arguments(curr_node, bufnr, {
       vim.api.nvim_win_get_cursor(0)[1] - 1,
       vim.api.nvim_win_get_cursor(0)[2],
     })
@@ -266,8 +309,11 @@ local function make_lsp_request(buf, method, params)
       return { line = i.text, id = index }
     end, arguments)
 
-    ui.open_ui(lines, ts.get_node_text(curr_node, buf, {}), function(swaped_lines)
-      local positions = vim
+    ui.open_ui(
+      lines,
+      ts.get_node_text(curr_node, bufnr, {}),
+      function(swaped_lines)
+        local positions = vim
           .iter(results)
           :map(function(res)
             return res.result
@@ -278,23 +324,19 @@ local function make_lsp_request(buf, method, params)
           end)
           :totable()
 
-      update_at_positions(positions, swaped_lines)
-    end)
+        update_at_positions(positions, swaped_lines)
+      end
+    )
   end)
 end
 
---- Change the function variable locations
+---Change the function variable locations
 function M.change_function()
-  local method = "textDocument/references"
-  local params = {
-    textDocument = { uri = vim.uri_from_bufnr(api.nvim_get_current_buf()) },
-    position = convert_win_cursor_to_position(api.nvim_get_current_win()),
-  }
-  params.context = { includeDeclaration = true }
-
-  make_lsp_request(api.nvim_get_current_buf(), method, params)
+  M.change_function_via_lsp_references()
 end
 
+---Setup this plugin for usage.
+---@param opts? ChangeFunctionConfig
 function M.setup(opts)
   config_manager.set_default(opts)
   ui.set_config(config_manager)

--- a/lua/change-function/ui.lua
+++ b/lua/change-function/ui.lua
@@ -41,6 +41,10 @@ function M.set_config(config_manager)
   M.config = config_manager.config
 end
 
+---Open the UI to swap arguments
+---@param lines Argument[] The arguments that will be displayed in this UI
+---@param node_name string The title of this user interface
+---@param handler fun(swapped_args: Argument[])
 function M.open_ui(lines, node_name, handler)
   local popup = Popup(M.config.nui(node_name))
 
@@ -50,23 +54,23 @@ function M.open_ui(lines, node_name, handler)
     popup:unmount()
   end)
 
-  popup:map("n", M.config.mappings.move_down, function(_)
+  popup:map("n", M.config.mappings.move_down, function()
     move(popup.bufnr, lines, #lines, 1)
   end, { noremap = true })
 
-  popup:map("n", M.config.mappings.move_up, function(_)
+  popup:map("n", M.config.mappings.move_up, function()
     move(popup.bufnr, lines, 1, -1)
   end, { noremap = true })
 
-  popup:map("n", M.config.mappings.quit, function(_)
+  popup:map("n", M.config.mappings.quit, function()
     vim.cmd([[q]])
   end, { noremap = true })
 
-  popup:map("n", M.config.mappings.quit2, function(_)
+  popup:map("n", M.config.mappings.quit2, function()
     vim.cmd([[q]])
   end, { noremap = true })
 
-  popup:map("n", M.config.mappings.confirm, function(_)
+  popup:map("n", M.config.mappings.confirm, function()
     vim.cmd([[q]])
     vim.ui.select({ "Confirm", "Cancel" }, { prompt = "Are you sure?" }, function(i)
       if i == "Cancel" then

--- a/lua/change-function/ui.lua
+++ b/lua/change-function/ui.lua
@@ -72,12 +72,16 @@ function M.open_ui(lines, node_name, handler)
 
   popup:map("n", M.config.mappings.confirm, function()
     vim.cmd([[q]])
-    vim.ui.select({ "Confirm", "Cancel" }, { prompt = "Are you sure?" }, function(i)
-      if i == "Cancel" then
-        return
+    vim.ui.select(
+      { "Confirm", "Cancel" },
+      { prompt = "Are you sure?" },
+      function(i)
+        if i == "Cancel" then
+          return
+        end
+        handler(lines)
       end
-      handler(lines)
-    end)
+    )
   end, { noremap = true })
 
   update_lines(popup.bufnr, lines)

--- a/lua/change-function/utils.lua
+++ b/lua/change-function/utils.lua
@@ -1,0 +1,47 @@
+local M = {}
+
+--- Converts a position from the reference result and return a new position
+--- @param position {}
+--- @return Position
+function M.reference_position_to_position(position)
+  local bufnr = vim.uri_to_bufnr(position["uri"])
+  return {
+    bufnr = bufnr,
+    location = { position["range"]["start"]["line"], position["range"]["start"]["character"] },
+  }
+end
+
+function M.inside_range(range, pos)
+  return range.start.line <= pos[1]
+      and pos[1] <= range["end"].line
+      and range.start.character <= pos[2]
+      and pos[2] <= range["end"].character
+end
+
+--- Get the text and the range of a ndoe.
+--- @param node TSNode
+--- @return TextRange, string
+function M.range_text(node, bufnr)
+  local row1, col1, row2, col2 = node:range()
+  local range = {
+    start = {
+      line = row1,
+      character = col1,
+    },
+    ["end"] = {
+      line = row2,
+      character = col2,
+    },
+  }
+  local buf_text = (vim.api.nvim_buf_get_text(bufnr, row1, col1, row2, col2, {}))
+  local text = table.concat(buf_text, "\n")
+  return range, text
+end
+
+function M.convert_win_cursor_to_position(win)
+  local row, col = unpack(vim.api.nvim_win_get_cursor(win))
+  row = row - 1
+  return { line = row, character = col }
+end
+
+return M

--- a/lua/change-function/utils.lua
+++ b/lua/change-function/utils.lua
@@ -13,9 +13,9 @@ end
 
 function M.inside_range(range, pos)
   return range.start.line <= pos[1]
-      and pos[1] <= range["end"].line
-      and range.start.character <= pos[2]
-      and pos[2] <= range["end"].character
+    and pos[1] <= range["end"].line
+    and range.start.character <= pos[2]
+    and pos[2] <= range["end"].character
 end
 
 ---Get the text and the range of a ndoe.

--- a/lua/change-function/utils.lua
+++ b/lua/change-function/utils.lua
@@ -1,8 +1,8 @@
 local M = {}
 
---- Converts a position from the reference result and return a new position
---- @param position {}
---- @return Position
+---Converts a position from the reference result and return a new position
+---@param position {}
+---@return Position
 function M.reference_position_to_position(position)
   local bufnr = vim.uri_to_bufnr(position["uri"])
   return {
@@ -18,9 +18,9 @@ function M.inside_range(range, pos)
       and pos[2] <= range["end"].character
 end
 
---- Get the text and the range of a ndoe.
---- @param node TSNode
---- @return TextRange, string
+---Get the text and the range of a ndoe.
+---@param node TSNode
+---@return TextRange, string
 function M.range_text(node, bufnr)
   local row1, col1, row2, col2 = node:range()
   local range = {

--- a/lua/change-function/utils.lua
+++ b/lua/change-function/utils.lua
@@ -7,7 +7,10 @@ function M.reference_position_to_position(position)
   local bufnr = vim.uri_to_bufnr(position["uri"])
   return {
     bufnr = bufnr,
-    location = { position["range"]["start"]["line"], position["range"]["start"]["character"] },
+    location = {
+      position["range"]["start"]["line"],
+      position["range"]["start"]["character"],
+    },
   }
 end
 
@@ -33,7 +36,9 @@ function M.range_text(node, bufnr)
       character = col2,
     },
   }
-  local buf_text = (vim.api.nvim_buf_get_text(bufnr, row1, col1, row2, col2, {}))
+  local buf_text = (
+    vim.api.nvim_buf_get_text(bufnr, row1, col1, row2, col2, {})
+  )
   local text = table.concat(buf_text, "\n")
   return range, text
 end


### PR DESCRIPTION
Close #6 

Thanks to @colinkennedy for the idea!

Introduces the new function `change_function_via_qf` to be able to change the functions in the quickfix list.

This also adds the option `quickfix_source` to select whether the arguments in the popup window are from the `cursor` or the selected `entry` within the quickfix list.